### PR TITLE
Fixed Sql injection 

### DIFF
--- a/tools/bltzero_admin.py
+++ b/tools/bltzero_admin.py
@@ -12,6 +12,10 @@ def run(cmd):
         sys.exit(p.returncode)
     return p.stdout
 
+def esc(v):
+    """Escape single quotes for safe SQL string interpolation."""
+    return v.replace("'", "''")
+
 def add_domain(args):
     pub = pathlib.Path(args.public_key).read_text(encoding="utf-8").strip()
     # Validate JSON
@@ -21,7 +25,7 @@ def add_domain(args):
 
     sql = f"""
 INSERT INTO domains (domain, org_email, alg, key_id, public_key_jwk, is_active)
-VALUES ('{args.domain}', '{args.email}', 'ECDH_P256_HKDF_SHA256_AESGCM', '{args.key_id}', '{pub.replace("'", "''")}', 1)
+VALUES ('{esc(args.domain)}', '{esc(args.email)}', 'ECDH_P256_HKDF_SHA256_AESGCM', '{esc(args.key_id)}', '{esc(pub)}', 1)
 ON CONFLICT(domain) DO UPDATE SET
   org_email=excluded.org_email,
   alg=excluded.alg,


### PR DESCRIPTION
1. Entry point main() at line 37 uses argparse to parse CLI arguments: --domain, --email, --key-id, --public-key.
2. No sanitization — args.domain, args.email, and args.key_id are interpolated directly into the SQL string via f-string at lines 22–31. Only pub (the public key file contents) gets a single-quote escape (.replace("'", "''")).
3. SQL execution The assembled SQL is passed to wrangler d1 execute --command via shlex.quote() at line 33, which protects against shell injection but does nothing for SQL injection.

Wouldn't be worth exploiting since the operator already has full access to DB. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved string data handling in database operations within the admin tool to enhance data integrity and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->