### PR TITLE
Document and harden BLT points/BACON sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ BLT-Zero provides a **zero-trust workflow** for delivering vulnerability reports
 - 🛡️ Rate limiting
 - 🧩 Optional Turnstile
   - Can be disabled for local dev using `DISABLE_TURNSTILE=true`
-- 📊 Optional points sync to main BLT
+- 📊 Optional points/BACON sync to main BLT (metadata-only; no report contents)
 
 ---
 
@@ -167,6 +167,32 @@ This will generate:
 ```bash
 python tools/org_decrypt.py private_key.jwk package.json
 ```
+
+### Optional BLT points / BACON sync
+
+BLT-Zero can **optionally** award BLT points/BACON for successful encrypted submissions
+without ever sending plaintext report data to the main BLT platform.
+
+- If the reporter supplies a `username` and you configure BLT sync, the Worker will
+  POST a small JSON payload to the main BLT API:
+
+  ```json
+  { "username": "<reporter>", "domain_name": "<program domain>" }
+  ```
+
+- No report content, ciphertext, or fields derived from the encrypted package are sent.
+
+To enable this integration:
+
+1. Configure the following variables in `wrangler.toml` / `.dev.vars`:
+
+   - `MAIN_BLT_API_URL` – base URL for the BLT API (defaults to `https://api.owaspblt.org`)
+   - `MAIN_BLT_API_TOKEN` – BLT API token with permission to award points for Zero-Trust submissions
+
+2. Deploy BLT-Zero with those values set.
+
+If `MAIN_BLT_API_TOKEN` is not set, BLT sync is silently skipped and submissions
+remain purely local to BLT-Zero.
 
 ## 🤝 Contributing
 

--- a/src/services/email.py
+++ b/src/services/email.py
@@ -91,9 +91,14 @@ async def sync_points(env, username, domain):
     headers.set("content-type", "application/json")
     headers.set("authorization", f"Token {token}")
     
-    await fetch(
-        f"{env.MAIN_BLT_API_URL}/api/v1/zero-trust-points/",
-        method="POST",
-        headers=headers,
-        body=json.dumps({"username": username, "domain_name": domain})
-    )
+    try:
+        await fetch(
+            f"{env.MAIN_BLT_API_URL}/api/v1/zero-trust-points/",
+            method="POST",
+            headers=headers,
+            body=json.dumps({"username": username, "domain_name": domain}),
+        )
+    except Exception:
+        # Best-effort only: never block the submission path if BLT sync fails.
+        # Intentionally avoid logging username or domain here to preserve privacy.
+        return

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -13,8 +13,8 @@ directory = "./static"
 
 [vars]
 APP_ORIGIN = "https://zero.owaspblt.org"
-MAIN_BLT_API_URL = "https://api.owaspblt.org"
-POINTS_AWARD = "3"
+MAIN_BLT_API_URL = "https://api.owaspblt.org" # Base URL for optional BLT points/BACON sync
+POINTS_AWARD = "3" # Default points awarded per successful encrypted submission (used by BLT API)
 MAX_UPLOAD_BYTES = "3145728" # 3 MiB encrypted package cap
 RATE_LIMIT_PER_MINUTE = "5"
 


### PR DESCRIPTION
This PR documents and slightly hardens the optional BLT points/BACON integration in BLT‑Zero.

### What’s included

- **README**
  - Expands the “Features” section to clarify that points/BACON sync to BLT is **metadata-only** and never sends report contents or ciphertext.
  - Adds an “Optional BLT points / BACON sync” section explaining:
    - When a reporter provides a `username` and sync is configured, BLT‑Zero POSTs a small payload to BLT:
      ```json
      { "username": "<reporter>", "domain_name": "<program domain>" }
      ```
    - How to enable it by setting `MAIN_BLT_API_URL` and `MAIN_BLT_API_TOKEN`.
    - That if `MAIN_BLT_API_TOKEN` is unset, sync is silently skipped.

- **Config (`wrangler.toml`)**
  - Documents `MAIN_BLT_API_URL` as the base URL for the optional BLT sync.
  - Documents `POINTS_AWARD` as the default points per successful encrypted submission (used by the BLT API).

- **Worker (`src/services/email.py`)**
  - Makes `sync_points` explicitly **best‑effort and non‑blocking** by catching any exceptions from the outbound `fetch`.
  - Intentionally avoids logging `username` or `domain` inside `sync_points` to preserve BLT‑Zero’s privacy guarantees.

### Why

- Keeps BLT‑Zero’s **zero‑trust model** intact while making it easier for BLT to award points/BACON for Zero‑Trust submissions.
- Clarifies configuration and behaviour so operators can safely enable or disable BLT sync without affecting report delivery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded docs for optional BLT/BACON metadata-only sync with configuration, payload, and deployment guidance.

* **Bug Fixes**
  * BLT sync made best-effort and non-blocking so external sync failures no longer break submissions.

* **Tests**
  * Added unit tests covering security utilities and turnstile enablement scenarios; test runtime shims added.

* **CI**
  * Added CI workflow to run linting and tests.

* **Chores**
  * Clarified config comments and reordered related entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->