### PR TITLE
feat(submit): add screenshot preview grid with remove + live size/count checks

### DIFF
--- a/src/pages/submit.html
+++ b/src/pages/submit.html
@@ -250,9 +250,8 @@ shotsInput.addEventListener('change', () => {
 });
 
 function getFilesForZip(){
-  // Use curated list if any, else fall back to raw input files
-  return selectedShots.length ? selectedShots.map(s => s.file)
-                              : Array.from(shotsInput.files || []);
+  // Always use curated preview state as source of truth
+  return selectedShots.map(s => s.file);
 }
 
 function clearPreviews(){

--- a/src/pages/submit.html
+++ b/src/pages/submit.html
@@ -134,6 +134,8 @@
                 multiple 
                 class="w-full px-4 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-dark-base text-gray-900 dark:text-gray-50 focus:outline-none focus:ring-2 focus:ring-primary file:mr-4 file:py-1 file:px-3 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-primary file:text-white hover:file:bg-primary/90 cursor-pointer transition-colors"
               />
+              <div id="shots-info" class="mt-2 text-xs text-gray-600 dark:text-gray-400"></div>
+              <div id="shots-preview" class="mt-3 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
             </div>
 
             <button 
@@ -168,6 +170,101 @@ const btn = document.getElementById("btn");
 const msgContainer = document.getElementById("msgContainer");
 const msg = document.getElementById("msg");
 
+// --- Screenshot preview: state + UI ---
+const shotsInput = document.getElementById("shots");
+const shotsInfo = document.getElementById("shots-info");
+const shotsPreview = document.getElementById("shots-preview");
+const limitFilesEl = document.getElementById("limitFiles");
+const limitBytesEl = document.getElementById("limitBytes");
+
+const MAX_FILES = Number(limitFilesEl.textContent || 5);
+const MAX_TOTAL_BYTES = Number(limitBytesEl.textContent || 5242880);
+
+let selectedShots = []; // [{ file: File, url: string }]
+
+function humanSize(bytes){
+  if(bytes < 1024) return `${bytes} B`;
+  if(bytes < 1024*1024) return `${(bytes/1024).toFixed(1)} KB`;
+  return `${(bytes/1024/1024).toFixed(1)} MB`;
+}
+
+function updateShotsInfo(){
+  const count = selectedShots.length;
+  const total = selectedShots.reduce((a, s) => a + s.file.size, 0);
+  const overCount = count > MAX_FILES;
+  const overSize = total > MAX_TOTAL_BYTES;
+
+  shotsInfo.textContent =
+    `Selected ${count}/${MAX_FILES} • Total ${humanSize(total)} / ${humanSize(MAX_TOTAL_BYTES)}` +
+    (overCount ? ' • Too many files' : '') +
+    (overSize ? ' • Total size too large' : '');
+}
+
+function renderPreviews(){
+  shotsPreview.innerHTML = '';
+  selectedShots.forEach((item, idx) => {
+    const card = document.createElement('div');
+    card.className = 'relative border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden bg-white dark:bg-dark-base';
+
+    const img = document.createElement('img');
+    img.src = item.url;
+    img.alt = item.file.name;
+    img.className = 'w-full h-72 object-cover';
+
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = '×';
+    btn.title = 'Remove';
+    btn.className = 'absolute top-1.5 right-1.5 bg-black/70 text-white rounded-full w-6 h-6 leading-6 text-center text-xs hover:bg-red-600';
+    btn.addEventListener('click', () => {
+      URL.revokeObjectURL(item.url);
+      selectedShots.splice(idx, 1);
+      renderPreviews();
+      updateShotsInfo();
+    });
+
+    const meta = document.createElement('div');
+    meta.className = 'px-2 py-1 text-[10px] sm:text-xs text-gray-600 dark:text-gray-400 truncate border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-dark-base';
+    meta.textContent = `${item.file.name} • ${humanSize(item.file.size)}`;
+
+    card.append(img, btn, meta);
+    shotsPreview.appendChild(card);
+  });
+}
+
+shotsInput.addEventListener('change', () => {
+  const incoming = Array.from(shotsInput.files || []);
+  for(const f of incoming){
+    if(!f.type || !f.type.startsWith('image/')) continue;
+    const key = `${f.lastModified}:${f.name}:${f.size}`;
+    const exists = selectedShots.some(s => `${s.file.lastModified}:${s.file.name}:${s.file.size}` === key);
+    if(exists) continue;
+    selectedShots.push({ file: f, url: URL.createObjectURL(f) });
+  }
+  if(selectedShots.length > MAX_FILES){
+    const extra = selectedShots.splice(MAX_FILES);
+    extra.forEach(e => URL.revokeObjectURL(e.url));
+  }
+  renderPreviews();
+  updateShotsInfo();
+});
+
+function getFilesForZip(){
+  // Use curated list if any, else fall back to raw input files
+  return selectedShots.length ? selectedShots.map(s => s.file)
+                              : Array.from(shotsInput.files || []);
+}
+
+function clearPreviews(){
+  selectedShots.forEach(s => URL.revokeObjectURL(s.url));
+  selectedShots = [];
+  shotsPreview.innerHTML = '';
+  updateShotsInfo();
+}
+
+// Initialize info line on load
+updateShotsInfo();
+
 function showErr(text){
 msgContainer.classList.remove("hidden");
 msg.className="msg-error";
@@ -201,7 +298,7 @@ const url=document.getElementById("url").value.trim();
 const description=document.getElementById("description").value.trim();
 const markdown=document.getElementById("markdown").value.trim();
 
-const files=Array.from(document.getElementById("shots").files||[]);
+const files = getFilesForZip();
 const maxFiles=Number(document.getElementById("limitFiles").textContent);
 const maxTotalBytes=Number(document.getElementById("limitBytes").textContent);
 const totalBytes=files.reduce((sum,file)=>sum+file.size,0);
@@ -263,6 +360,7 @@ if(!res.ok)throw new Error(data.error||"Server rejected submission");
 
 showOk(`Success! Report encrypted and sent.\nArtifact Hash: ${data.artifact_hash}`);
 form.reset();
+clearPreviews();
 
 }catch(err){
 showErr(err.message);


### PR DESCRIPTION
Closes #19 
Summary:-

- Adds client‑side screenshot preview to src/pages/submit.html (thumbnails, filename + size, per‑item remove).
- Enforces MAX_FILES and ZIP_MAX_TOTAL_BYTES client‑side with live counter; mirrors server limits.
- Submit handler now uses curated selection from the preview; cleans up previews after success.

Screenshots:-

<img width="1919" height="866" alt="Screenshot 2026-04-14 001307" src="https://github.com/user-attachments/assets/2dd23d0e-dfc9-4b2c-9914-f2b6690fc2a4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Screenshot selection and preview management** – Users can now view thumbnails and file metadata for selected images before submission. This includes the ability to remove unwanted files individually, automatic detection and filtering of duplicates, and intelligent file limit enforcement to ensure submissions remain within acceptable size constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->